### PR TITLE
Add Claude Code native install to bootstrap

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -9,3 +9,6 @@
 if [[ ( "$SHLVL" -eq 1 && ! -o LOGIN ) && -s "${ZDOTDIR:-$HOME}/.zprofile" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprofile"
 fi
+source "/Users/ichihashi/.rover/env"
+
+export PATH="$HOME/.local/bin:$PATH"

--- a/.zshenv
+++ b/.zshenv
@@ -9,6 +9,4 @@
 if [[ ( "$SHLVL" -eq 1 && ! -o LOGIN ) && -s "${ZDOTDIR:-$HOME}/.zprofile" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprofile"
 fi
-source "/Users/ichihashi/.rover/env"
-
 export PATH="$HOME/.local/bin:$PATH"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -25,6 +25,10 @@ elif [ "$(uname)" == "Darwin" ]; then
   task "Install Homebrew packages" "brew.sh"
 fi
 
+if [ "$(uname)" == "Linux" ] || [ "$(uname)" == "Darwin" ]; then
+  task "Install Claude Code" "claude.sh"
+fi
+
 task "Install prezto" "prezto.sh"
 task "Install Tmux Plugin Manager" "tpm.sh"
 task "Install fzf" "fzf.sh"

--- a/bootstrap/claude.sh
+++ b/bootstrap/claude.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+# https://code.claude.com/docs/ja/quickstart#native-install-recommended
+
+if command -v claude &> /dev/null; then
+  echo "claude is already installed."
+  exit 0
+fi
+
+OS=$(uname -s)
+if [ "$OS" != "Linux" ] && [ "$OS" != "Darwin" ]; then
+  echo "This script supports macOS and Linux only."
+  exit 1
+fi
+
+curl -fsSL https://claude.ai/install.sh | bash
+
+exit 0


### PR DESCRIPTION
## Summary
- add Claude Code native install bootstrap script
- run it for macOS and Linux in the bootstrap flow

## Testing
- not run (not requested)