### PR TITLE
Update global gitignore

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -1,5 +1,3 @@
-.envrc
-.env
-.tool-versions
 
+.DS_Store
 **/.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Remove project-specific entries (`.envrc`, `.env`, `.tool-versions`) from global gitignore
- Add `.DS_Store` to global gitignore

## Test plan
- [ ] Verify `.DS_Store` files are ignored globally
- [ ] Verify `.envrc`, `.env`, `.tool-versions` are no longer globally ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)