### PR TITLE
Fix credential helper to be portable across environments

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -66,6 +66,11 @@
   wtl = worktree list
 
 [credential "https://github.com"]
+  helper = ""
+  helper = "!gh auth git-credential"
+
+[credential "https://gist.github.com"]
+  helper = ""
   helper = "!gh auth git-credential"
 
 # Private settings that can not be published in the repository


### PR DESCRIPTION
## Summary
- Reset credential helper chain with empty `helper = ""` to override system-level `osxkeychain` (Xcode)
- Use PATH-based `gh` command instead of absolute path (`/opt/homebrew/bin/gh`) for cross-platform compatibility
- Add `gist.github.com` credential config

## Background
`gh auth setup-git` writes absolute paths to `.gitconfig`, which breaks when sharing dotfiles across macOS/Ubuntu. This change uses the portable `"!gh auth git-credential"` form instead, and `gh auth switch` alone handles account switching without needing `gh auth setup-git` each time.

## Test plan
- [x] Verified `gh auth switch` correctly switches git credentials on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)