### PR TITLE
Update dev tools and terminal config

### DIFF
--- a/.config/cmux/settings.json
+++ b/.config/cmux/settings.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux-settings.schema.json",
+  "schemaVersion": 1,
+  "shortcuts": {
+    "bindings": {
+      "newSurface": ["ctrl+a", "c"],
+      "closeTab": ["ctrl+a", "x"],
+      "nextSurface": ["ctrl+a", "n"],
+      "prevSurface": ["ctrl+a", "p"],
+      "splitRight": ["ctrl+a", "\\"],
+      "splitDown": ["ctrl+a", "-"],
+      "focusLeft": ["ctrl+a", "h"],
+      "focusDown": ["ctrl+a", "j"],
+      "focusUp": ["ctrl+a", "k"],
+      "focusRight": ["ctrl+a", "l"],
+      "toggleSplitZoom": ["ctrl+a", "z"],
+      "toggleTerminalCopyMode": ["ctrl+a", "["],
+      "renameTab": ["ctrl+a", ","],
+      "renameWorkspace": ["ctrl+a", "$"],
+      "goToWorkspace": ["ctrl+a", "w"],
+      "commandPalette": ["ctrl+a", ":"]
+    }
+  }
+}

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,0 +1,2 @@
+font-size = 12
+theme = One Dark

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -16,6 +16,7 @@ setw -g mode-keys vi  # Use vi key bindings in copy mode.
 bind-key -T copy-mode-vi v send -X begin-selection  # Start the copy mode selection from 'v'.
 
 set -g @continuum-restore 'on'
+set -g allow-passthrough on
 
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-pain-control'

--- a/.zshrc
+++ b/.zshrc
@@ -108,12 +108,9 @@ fi
 # Pulumi completion
 [ $commands[pulumi] ] && source <(pulumi gen-completion zsh)
 
-# mise (Linux only; Homebrew auto-activates on macOS)
-# https://mise.jdx.dev/
-if [[ "$(uname)" == "Linux" ]] && command -v mise &> /dev/null; then
-  eval "$(mise activate zsh)"
-  eval "$(mise completion zsh)"
-fi
+# mise
+eval "$(mise activate zsh)"
+eval "$(mise completion zsh)"
 
 # Azure CLI completion
 if [[ -f "$HOME/.azure/az.completion" ]] then;
@@ -163,3 +160,4 @@ function unset-aws-mfa() {
   unset AWS_SECRET_ACCESS_KEY
   unset AWS_SESSION_TOKEN
 }
+

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -27,6 +27,7 @@ fi
 
 if [ "$(uname)" == "Linux" ] || [ "$(uname)" == "Darwin" ]; then
   task "Install Claude Code" "claude.sh"
+  task "Install Cursor CLI" "cursor-cli.sh"
 fi
 
 task "Install prezto" "prezto.sh"

--- a/bootstrap/cursor-cli.sh
+++ b/bootstrap/cursor-cli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# https://cursor.com/docs/cli/installation
+
+if command -v agent &> /dev/null; then
+  echo "cursor agent is already installed."
+  exit 0
+fi
+
+curl -fsSL https://cursor.com/install | bash
+
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,7 @@ function mklinks() {
   mklink ".awsp-wrapper"
   mklink ".vimrc"
   mklink ".config/git" ${CONFDIR}
+  mklink ".config/cmux" ${CONFDIR}
 
   if [ "$(uname)" == "Darwin" ]; then
     mklink ".Brewfile"

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ function mklinks() {
   mklink ".vimrc"
   mklink ".config/git" ${CONFDIR}
   mklink ".config/cmux" ${CONFDIR}
+  mklink ".config/ghostty" ${CONFDIR}
 
   if [ "$(uname)" == "Darwin" ]; then
     mklink ".Brewfile"


### PR DESCRIPTION
## Summary
- Add cmux keyboard shortcuts mirroring tmux config (Ctrl+A prefix, pain-control splits, vi-style pane navigation)
- Add Ghostty config for cmux terminal appearance (font-size=12, One Dark theme)
- Enable tmux allow-passthrough
- Activate mise on all platforms (was Linux only)
- Add Cursor CLI bootstrap script

## Test plan
- [ ] Verify cmux shortcuts work (Ctrl+A prefix, splits, pane navigation)
- [ ] Verify Ghostty theme and font size applied in cmux
- [ ] Run `install.sh` to confirm symlinks created for cmux and ghostty
- [ ] Verify mise activates correctly on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)